### PR TITLE
closes #278: add NULL check to char* logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler:
 before_install:
  - sudo apt-get update
  - sudo apt-get install libgtest-dev
- - "cd /usr/src/gtest && sudo cmake . && sudo cmake --build . && sudo mv libg* /usr/local/lib/ ; cd -"
+ - sudo PATH="${PATH}" sh -c "cd /usr/src/gtest && cmake . && cmake --build . && mv libg* /usr/local/lib/ ; cd -"
 before_script:
  - pwd
  - cd samples/STL/

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -4562,6 +4562,17 @@ public:
         return *this;\
     }
 
+#   define ELPP_SIMPLE_LOG_PTR(LOG_TYPE)\
+    inline MessageBuilder& operator<<(LOG_TYPE msg) {\
+        if (msg) {\
+            m_logger->stream() << msg;\
+            if (ELPP->hasFlag(LoggingFlag::AutoSpacing)) {\
+                m_logger->stream() << " ";\
+            }\
+        }\
+        return *this;\
+    }
+
     inline MessageBuilder& operator<<(const std::string& msg) {
         return operator<<(msg.c_str());
     }
@@ -4575,8 +4586,8 @@ public:
     ELPP_SIMPLE_LOG(unsigned long)
     ELPP_SIMPLE_LOG(float)
     ELPP_SIMPLE_LOG(double)
-    ELPP_SIMPLE_LOG(char*)
-    ELPP_SIMPLE_LOG(const char*)
+    ELPP_SIMPLE_LOG_PTR(char*)
+    ELPP_SIMPLE_LOG_PTR(const char*)
     ELPP_SIMPLE_LOG(const void*)
     ELPP_SIMPLE_LOG(long double)
     inline MessageBuilder& operator<<(const std::wstring& msg) {
@@ -4845,6 +4856,7 @@ public:
     // Other classes
     template <class Class>
     ELPP_SIMPLE_LOG(const Class&)
+#undef ELPP_SIMPLE_LOG_PTR
 #undef ELPP_SIMPLE_LOG
 #undef ELPP_ITERATOR_CONTAINER_LOG_ONE_ARG
 #undef ELPP_ITERATOR_CONTAINER_LOG_TWO_ARG

--- a/test/issues-test.h
+++ b/test/issues-test.h
@@ -1,0 +1,20 @@
+#ifndef ISSUESTEST_H_
+#define ISSUESTEST_H_
+
+#include "test.h"
+
+// https://github.com/easylogging/easyloggingpp/issues/278
+TEST(IssuesTest, Issue278) {
+    // first log a nullptr
+    const char* null_ptr = nullptr;
+    LOG(INFO) << "char* nullptr:" << null_ptr;
+    std::string expected = BUILD_STR(getDate() << " char* nullptr:\n");
+    EXPECT_EQ(expected, tail(1));
+
+    // then log something else and see if it is broken
+    LOG(INFO) << "issue278";
+    expected = BUILD_STR(getDate() << " issue278\n");
+    EXPECT_EQ(expected, tail(1));
+}
+
+#endif // ISSUESTEST_H_

--- a/test/main.cc
+++ b/test/main.cc
@@ -13,6 +13,7 @@
 #include "global-configurations-test.h"
 #include "helpers-test.h"
 #include "hit-counter-test.h"
+#include "issues-test.h"
 #include "log-format-resolution-test.h"
 #include "loggable-test.h"
 #include "logger-test.h"


### PR DESCRIPTION
Implemented through the macro `ELPP_SIMPLE_LOG_PTR` which is the same as
`ELPP_SIMPLE_LOG`, but does a NULL pointer check.  The auto-space is not
included if the pointer check fails.

void\* loggin intentionally does not use `ELPP_SIMPLE_LOG_PTR` as it should
log a raw pointer value.

Added unit test, which fails without the fix (under gcc 4.8.1).
This test in `issues-test.h` as a place for future issues.
