### PR TITLE
Add support for log file truncation at startup

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -589,6 +589,8 @@ enum class ConfigurationType : base::type::EnumType {
     MaxLogFileSize = 128,
    /// @brief Specifies number of log entries to hold until we flush pending log data
     LogFlushThreshold = 256,
+   /// @brief Specifes that the log should be truncated at log startup
+    LogFileTruncate = 512,
    /// @brief Represents unknown configuration
     Unknown = 1010
 };
@@ -620,6 +622,7 @@ public:
         if (configurationType == ConfigurationType::PerformanceTracking) return "PERFORMANCE_TRACKING";
         if (configurationType == ConfigurationType::MaxLogFileSize) return "MAX_LOG_FILE_SIZE";
         if (configurationType == ConfigurationType::LogFlushThreshold) return "LOG_FLUSH_THRESHOLD";
+        if (configurationType == ConfigurationType::LogFileTruncate) return "LOG_FILE_TRUNCATE";
         return "UNKNOWN";
     }
     /// @brief Converts from configStr to ConfigurationType
@@ -644,6 +647,8 @@ public:
             return ConfigurationType::MaxLogFileSize;
         if ((strcmp(configStr, "LOG_FLUSH_THRESHOLD") == 0) || (strcmp(configStr, "log_flush_threshold") == 0))
             return ConfigurationType::LogFlushThreshold;
+        if ((strcmp(configStr, "LOG_FILE_TRUNCATE") == 0) || (strcmp(configStr, "log_file_truncate") == 0))
+            return ConfigurationType::LogFileTruncate;
         return ConfigurationType::Unknown;
     }
     /// @brief Applies specified function to each configuration type starting from startIndex
@@ -2592,6 +2597,7 @@ public:
         setGlobally(ConfigurationType::PerformanceTracking, std::string("true"), true);
         setGlobally(ConfigurationType::MaxLogFileSize, std::string("0"), true);
         setGlobally(ConfigurationType::LogFlushThreshold, std::string("0"), true);
+        setGlobally(ConfigurationType::LogFileTruncate, std::string("0"), true);
 
         setGlobally(ConfigurationType::Format, std::string("%datetime %level [%logger] %msg"), true);
         set(Level::Debug, ConfigurationType::Format, std::string("%datetime %level [%logger] [%user@%host] [%func] [%loc] %msg"));
@@ -2906,6 +2912,9 @@ public:
         return getConfigByVal<std::size_t>(level, &m_logFlushThresholdMap, "logFlushThreshold");
     }
 
+    inline std::size_t logFileTruncate(Level level) {
+        return getConfigByVal<bool>(level, &m_logFileTruncateMap, "logFileTruncate");
+    }
 private:
     Configurations* m_configurations;
     std::map<Level, bool> m_enabledMap;
@@ -2918,6 +2927,7 @@ private:
     std::map<Level, base::FileStreamPtr> m_fileStreamMap;
     std::map<Level, std::size_t> m_maxLogFileSizeMap;
     std::map<Level, std::size_t> m_logFlushThresholdMap;
+	 std::map<Level, bool> m_logFileTruncateMap;
     base::LogStreamsReferenceMap* m_logStreamsReference;
 
     friend class el::Helpers;
@@ -3031,6 +3041,8 @@ private:
 #endif  // !defined(ELPP_NO_DEFAULT_LOG_FILE)
             } else if (conf->configurationType() == ConfigurationType::LogFlushThreshold) {
                 setValue(conf->level(), static_cast<std::size_t>(getULong(conf->value())), &m_logFlushThresholdMap);
+            } else if (conf->configurationType() == ConfigurationType::LogFileTruncate) {
+                setValue(conf->level(), getBool(conf->value()), &m_logFileTruncateMap);
             }
         }
         // As mentioned early, we will now set filename configuration in separate loop to deal with non-existent files
@@ -3129,6 +3141,13 @@ private:
                 ELPP_INTERNAL_ERROR("Setting [TO_FILE] of [" 
                     << LevelHelper::convertToString(level) << "] to FALSE", false);
                 setValue(level, false, &m_toFileMap);
+            } else {
+					bool truncate = unsafeGetConfigByVal(level, &m_logFileTruncateMap, "logFileTruncate");
+					if (truncate == true) {
+						std::string fname = unsafeGetConfigByRef(level, &m_filenameMap, "filename");
+						fs->close();
+						fs->open(fname, std::fstream::out | std::fstream::trunc);
+					}
             }
         };
         // If we dont have file conf for any level, create it for Level::Global first


### PR DESCRIPTION
Added configuration flag for a logger that will truncate the log file before logger starts logging.  This option is useful a new logfile is desired each time the application is run.

This was modified from my previous request to get rid of the clang error in the test suite.  It's also a better solution in general.
