### PR TITLE
Add options to build as a static library and log in UTC time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,29 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(Easyloggingpp CXX)
 
-option(test "Build all tests" OFF)
-
-set(ELPP_MAJOR_VERSION "9")
-set(ELPP_MINOR_VERSION "94")
-set(ELPP_PATCH_VERSION "1")
-set(ELPP_VERSION_STRING "${ELPP_MAJOR_VERSION}.${ELPP_MINOR_VERSION}.${ELPP_PATCH_VERSION}")
-
-set(ELPP_INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "The directory the headers are installed in")
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
-
-install(FILES
-    src/easylogging++.h
-    src/easylogging++.cc
-    DESTINATION "${ELPP_INCLUDE_INSTALL_DIR}"
-    COMPONENT dev)
-
-export(PACKAGE ${PROJECT_NAME})
-
-
-########################################## Unit Testing ###################################
-if (test)
-        # We need C++11
+macro(require_cpp11)
         if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.0)
                 # CMake 3.1 has built-in CXX standard checks.
                 message("-- Setting C++11")
@@ -41,8 +19,43 @@ if (test)
                     message ("-- Easylogging++ requires C++11. Your compiler does not support it.")
                 endif()
         endif()
+endmacro()
 
-        set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
+option(test "Build all tests" OFF)
+option(build_static_lib "Build easyloggingpp as a static library" OFF)
+
+set(ELPP_MAJOR_VERSION "9")
+set(ELPP_MINOR_VERSION "94")
+set(ELPP_PATCH_VERSION "1")
+set(ELPP_VERSION_STRING "${ELPP_MAJOR_VERSION}.${ELPP_MINOR_VERSION}.${ELPP_PATCH_VERSION}")
+
+set(ELPP_INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "The directory the headers are installed in")
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+install(FILES
+    src/easylogging++.h
+    src/easylogging++.cc
+    DESTINATION "${ELPP_INCLUDE_INSTALL_DIR}"
+    COMPONENT dev)
+
+if (build_static_lib)
+        require_cpp11()
+        add_library(easyloggingpp STATIC src/easylogging++.cc)
+
+        install(TARGETS
+            easyloggingpp
+            ARCHIVE DESTINATION lib)
+endif()
+
+export(PACKAGE ${PROJECT_NAME})
+
+
+########################################## Unit Testing ###################################
+if (test)
+    # We need C++11
+    require_cpp11()
+    set (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
     find_package (gtest REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ endmacro()
 
 option(test "Build all tests" OFF)
 option(build_static_lib "Build easyloggingpp as a static library" OFF)
+option(lib_utc_datetime "Build library with UTC date/time logging" OFF)
 
 set(ELPP_MAJOR_VERSION "9")
 set(ELPP_MINOR_VERSION "94")
@@ -40,6 +41,10 @@ install(FILES
     COMPONENT dev)
 
 if (build_static_lib)
+        if (lib_utc_datetime)
+                add_definitions(-DELPP_UTC_DATETIME)
+        endif()
+
         require_cpp11()
         add_library(easyloggingpp STATIC src/easylogging++.cc)
 

--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -1140,19 +1140,19 @@ unsigned long long DateTime::getTimeDifference(const struct timeval& endTime, co
 struct ::tm* DateTime::buildTimeInfo(struct timeval* currTime, struct ::tm* timeInfo) {
 #if ELPP_OS_UNIX
   time_t rawTime = currTime->tv_sec;
-  ::localtime_r(&rawTime, timeInfo);
+  ::elpptime_r(&rawTime, timeInfo);
   return timeInfo;
 #else
 #  if ELPP_COMPILER_MSVC
   ELPP_UNUSED(currTime);
   time_t t;
   _time64(&t);
-  localtime_s(timeInfo, &t);
+  elpptime_s(timeInfo, &t);
   return timeInfo;
 #  else
   // For any other compilers that don't have CRT warnings issue e.g, MinGW or TDM GCC- we use different method
   time_t rawTime = currTime->tv_sec;
-  struct tm* tmInf = localtime(&rawTime);
+  struct tm* tmInf = elpptime(&rawTime);
   *timeInfo = *tmInf;
   return timeInfo;
 #  endif  // ELPP_COMPILER_MSVC

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -438,6 +438,15 @@ ELPP_INTERNAL_DEBUGGING_OUT_INFO << ELPP_INTERNAL_DEBUGGING_MSG(internalInfoStre
 // For logging wxWidgets based classes & templates
 #   include <wx/vector.h>
 #endif  // defined(ELPP_WXWIDGETS_LOGGING)
+#if defined(ELPP_UTC_DATETIME)
+#   define elpptime_r gmtime_r
+#   define elpptime_s gmtime_s
+#   define elpptime   gmtime
+#else
+#   define elpptime_r localtime_r
+#   define elpptime_s localtime_s
+#   define elpptime   localtime
+#endif  // defined(ELPP_UTC_DATETIME)
 // Forward declarations
 namespace el {
 class Logger;


### PR DESCRIPTION
This patch adds the ability to build easyloggingpp as a static library and to log in UTC time. Totally optional, nothing changes if the user chooses not to build the static library.