### PR TITLE
use base filename for vmodule wildcard matches

### DIFF
--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -1936,9 +1936,11 @@ bool VRegistry::allowed(base::type::VerboseLevel vlevel, const char* file) {
   if (m_modules.empty() || file == nullptr) {
     return vlevel <= m_level;
   } else {
+    char baseFilename[base::consts::kSourceFilenameMaxLength] = "";
+    base::utils::File::buildBaseFilename(file, baseFilename);
     std::map<std::string, base::type::VerboseLevel>::iterator it = m_modules.begin();
     for (; it != m_modules.end(); ++it) {
-      if (base::utils::Str::wildCardMatch(file, it->first.c_str())) {
+      if (base::utils::Str::wildCardMatch(baseFilename, it->first.c_str())) {
         return vlevel <= it->second;
       }
     }


### PR DESCRIPTION
In case __FILE__ macro expands to absolute or relative paths
the vmodule wildcard check fails if modules are only specified
with base filenames.

### This is a

- [ ] Breaking change
- [ ] New feature
- [X] Bugfix

### I have

- [X] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)


### Example
demo.cc:
```C++
#include "easylogging++.h"

#include "header.h"

INITIALIZE_EASYLOGGINGPP
int main(int argc, char* argv[]) {
  START_EASYLOGGINGPP(argc, argv);
  el::Loggers::removeFlag(el::LoggingFlag::AllowVerboseIfModuleNotSpecified);
  VLOG(1) << "demo: verbose 1 logging";
  VLOG(2) << "demo: verbose 2 logging";
  foo1();
  foo2();
  return 0;
}
```
header.h:
```C++
#pragma once

#include "easylogging++.h"

static inline void foo1() {
  VLOG(1) << "fooo verbosity 1";
}

static inline void foo2() {
  VLOG(2) << "fooo verbosity 2";
}
```

compile with: ``g++ demo.cc easylogging++.cc -o test -std=c++11 ``
example call that previously did not output anything: ``./test -vmodule=header=2``