### PR TITLE
fix compile when _USE_32_BIT_TIME_T defined

### DIFF
--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -1149,7 +1149,11 @@ struct ::tm* DateTime::buildTimeInfo(struct timeval* currTime, struct ::tm* time
 #  if ELPP_COMPILER_MSVC
   ELPP_UNUSED(currTime);
   time_t t;
+#if defined(_USE_32BIT_TIME_T)
+  _time32(&t);
+#else
   _time64(&t);
+#endif
   elpptime_s(timeInfo, &t);
   return timeInfo;
 #  else


### PR DESCRIPTION
### This is a

- [ ] Breaking change
- [ ] New feature
- [x] Bugfix

### I have

- [ ] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)
