### PR TITLE
Fix invalid parameter of utils::safeDelete got an invalid read of val…

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -905,7 +905,7 @@ namespace utils {
 template <typename T>
 static
 typename std::enable_if<std::is_pointer<T*>::value, void>::type
-safeDelete(T*& pointer) {
+safeDelete(T* pointer) {
   if (pointer == nullptr)
     return;
   delete pointer;
@@ -1467,8 +1467,8 @@ class Registry : public AbstractRegistry<T_Ptr, std::map<T_Key, T_Ptr*>> {
   void unregister(const T_Key& uniqKey) {
     T_Ptr* existing = get(uniqKey);
     if (existing != nullptr) {
-      base::utils::safeDelete(existing);
       this->list().erase(uniqKey);
+      base::utils::safeDelete(existing);
     }
   }
 


### PR DESCRIPTION
Fix error of valgrind & an abort of libasan when use call unregisterLogger.

Also the call of safe delete should be done after the erasure of the cell into the container.

Signed-off-by: Romain GASQ <r.gasq@ssi.samsung.com>

### This is a

- [ ] Breaking change
- [ ] New feature
- [ x] Bugfix

### I have

- [ ] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)
