### PR TITLE
Fix invalid usage of safeDelete which can cause an error with valgrin…

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -1467,8 +1467,8 @@ class Registry : public AbstractRegistry<T_Ptr, std::map<T_Key, T_Ptr*>> {
   void unregister(const T_Key& uniqKey) {
     T_Ptr* existing = get(uniqKey);
     if (existing != nullptr) {
-      base::utils::safeDelete(existing);
       this->list().erase(uniqKey);
+      base::utils::safeDelete(existing);
     }
   }
 


### PR DESCRIPTION
Fixed an invalid usage of safeDelete which can cause a valgrind & libasan error.


Signed-off-by: Romain GASQ

### This is a

- [ ] Breaking change
- [ ] New feature
- [ x] Bugfix

### I have

- [ ] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ x] [Run the tests](README.md#install-optional) 