### PR TITLE
Make static library /MT on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,10 @@ if (build_static_lib)
         require_cpp11()
         add_library(easyloggingpp STATIC src/easylogging++.cc)
 
+	if (MSVC)
+		target_compile_options(easyloggingpp PRIVATE "/MT$<$<CONFIG:Debug>:d>")
+	endif()
+
         install(TARGETS
             easyloggingpp
             ARCHIVE DESTINATION lib)


### PR DESCRIPTION
Static libraries are usually assumed to be /MT (instead CMake's default
/MD)

### This is a

- [x] Breaking change
- [ ] New feature
- [ ] Bugfix

### I have

- [x] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)
