### PR TITLE
Disable log file *initially* when using ELPP_NO_LOG_TO_FILE, to be consistent with documentation

### DIFF
--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -1698,12 +1698,6 @@ std::string TypedConfigurations::resolveFilename(const std::string& filename) {
 }
 
 void TypedConfigurations::insertFile(Level level, const std::string& fullFilename) {
-#if defined(ELPP_NO_LOG_TO_FILE)
-  setValue(level, false, &m_toFileMap);
-  ELPP_UNUSED(fullFilename);
-  m_fileStreamMap.insert(std::make_pair(level, base::FileStreamPtr(nullptr)));
-  return;
-#endif
   std::string resolvedFilename = resolveFilename(fullFilename);
   if (resolvedFilename.empty()) {
     std::cerr << "Could not load empty file for logging, please re-check your configurations for level ["


### PR DESCRIPTION
Currently, setting "ELPP_NO_LOG_TO_FILE" disables logging to file entirely. However, the documentation says it is only disabled initially.

When applying the current pull request, it is possible to disable it initially and set a custom log file location at runtime like this:

```
#define ELPP_NO_LOG_TO_FILE
#define ELPP_NO_DEFAULT_LOG_FILE

#include <easylogging++.h>

INITIALIZE_EASYLOGGINGPP

int main(int, char **) {
  el::Loggers::reconfigureAllLoggers(el::ConfigurationType::Filename,
                                     "test.log");
  el::Loggers::reconfigureAllLoggers(el::ConfigurationType::ToFile, "true");

  LOG(INFO) << "Test";
}
```

This is impossible with the current implementation.

### This is a

- [ ] Breaking change
- [ ] New feature
- [ x] Bugfix
