### PR TITLE
Add support for environment variables resolution in log file names

### DIFF
--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -814,6 +814,8 @@ static const char* kConfigurationLoggerId                  =      "--";
 static const std::size_t kSourceFilenameMaxLength          =      100;
 static const std::size_t kSourceLineMaxLength              =      10;
 static const Level kPerformanceTrackerDefaultLevel         =      Level::Info;
+static const char* kEnvVariableRegex                       =      "\\$\\{(.*)\\}";
+
 const struct {
   double value;
   const base::type::char_t* unit;
@@ -2073,6 +2075,7 @@ class TypedConfigurations : public base::threading::ThreadSafe {
 
   void build(Configurations* configurations);
   unsigned long getULong(std::string confVal);
+  std::string substituteEnvironmentVariables(const std::string& filename);
   std::string resolveFilename(const std::string& filename);
   void insertFile(Level level, const std::string& fullFilename);
   bool unsafeValidateFileRolling(Level level, const PreRollOutCallback& preRollOutCallback);


### PR DESCRIPTION
### This is a

- [ ] Breaking change
- [ ] New feature
- [ ] Bugfix

### I have

- [ ] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)

The syntax is cmake-like:
E.g., suppose we have ELPP_VAR as environment variable, then configuration file can look like this:

Global:
FORMAT = "%msg"
FILENAME = "matcher_${ELPP_VAR}.log"
ENABLED = true
TO_FILE = true
TO_STANDARD_OUTPUT = true
SUBSECOND_PRECISION = 6
PERFORMANCE_TRACKING = true
MAX_LOG_FILE_SIZE = 2097152 ## 2MB - Comment starts with two hashes (##)
LOG_FLUSH_THRESHOLD = 100 ## Flush after every 100 logs
In case ELPP_VAR is not set, it will be substituted with empty string.