### PR TITLE
respect MaxLogFileSize setting even when ELPP_NO_DEFAULT_LOG_FILE is set

### DIFF
--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -1621,10 +1621,12 @@ void TypedConfigurations::build(Configurations* configurations) {
     } else if (conf->configurationType() == ConfigurationType::PerformanceTracking) {
       setValue(Level::Global, getBool(conf->value()), &m_performanceTrackingMap);
     } else if (conf->configurationType() == ConfigurationType::MaxLogFileSize) {
-      setValue(conf->level(), static_cast<std::size_t>(getULong(conf->value())), &m_maxLogFileSizeMap);
-#if !defined(ELPP_NO_DEFAULT_LOG_FILE)
-      withFileSizeLimit.push_back(conf);
-#endif  // !defined(ELPP_NO_DEFAULT_LOG_FILE)
+      auto v = getULong(conf->value());
+      setValue(conf->level(), static_cast<std::size_t>(v), &m_maxLogFileSizeMap);
+      if (v != 0)
+      {
+          withFileSizeLimit.push_back(conf);
+      }
     } else if (conf->configurationType() == ConfigurationType::LogFlushThreshold) {
       setValue(conf->level(), static_cast<std::size_t>(getULong(conf->value())), &m_logFlushThresholdMap);
     }


### PR DESCRIPTION
It looks like defining `ELPP_NO_DEFAULT_LOG_FILE` disables features such as MaxLogFileSize even though `ELPP_NO_DEFAULT_LOG_FILE` is supposed to only impact the initial state (as per documentation).

While this fix changes the behavior, it should not really impact anybody:
it is safe to assume that somebody setting MaxLogFileSize does it when logging to a file.

### This is a

- [ ] Breaking change
- [ ] New feature
- [X] Bugfix

### I have

- [X] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)
