### PR TITLE
fix buffer underflow in getBashOutput

### DIFF
--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -997,8 +997,9 @@ const std::string OS::getBashOutput(const char* command) {
   char hBuff[4096];
   if (fgets(hBuff, sizeof(hBuff), proc) != nullptr) {
     pclose(proc);
-    if (hBuff[strlen(hBuff) - 1] == '\n') {
-      hBuff[strlen(hBuff) - 1] = '\0';
+    const size_t len = strlen(hBuff);
+    if (len > 0 && hBuff[len - 1] == '\n') {
+      hBuff[len - 1] = '\0';
     }
     return std::string(hBuff);
   } else {


### PR DESCRIPTION
### This is a

- [ ] Breaking change
- [ ] New feature
- [x ] Bugfix

### I have

- [ x] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)
