### PR TITLE
Update CHANGELOG after the file rolling change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - `ELPP_NO_DEFAULT_LOG_FILE` now logs to null device on major platforms (windows and unix)
 - Fixes unused warnings for constants
 
+### Updates
+- File rolling is now validated when flushing happens
+
 ## [9.96.2] - 27-02-2018
 ### Updates
 - Dispatcher now passes in pointer to log message instead of creating on the fly


### PR DESCRIPTION
Since I did not change the CHANGELOG file last time.

### This is a

- [ ] Breaking change
- [ ] New feature
- [x] Bugfix

### I have

- [x] Merged in the latest upstream changes
- [x] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [ ] [Run the tests](README.md#install-optional)
