### PR TITLE
generate PIC code for the library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ if (build_static_lib)
 
         require_cpp11()
         add_library(easyloggingpp STATIC src/easylogging++.cc)
+        set_property(TARGET easyloggingpp PROPERTY POSITION_INDEPENDENT_CODE ON)
 
         install(TARGETS
             easyloggingpp


### PR DESCRIPTION
I have some source files that use easyloggingpp (linking against the static library), and these files are later used to create a shared lib (.so).
Without this patch, I got linking error because the code is not position independant.

This patch fixes this issue.

### This is a

- [ ] Breaking change
- [ ] New feature
- [x] Bugfix

### I have

- [x] Merged in the latest upstream changes
- [ ] Updated [`CHANGELOG.md`](CHANGELOG.md)
- [ ] Updated [`README.md`](README.md)
- [x] [Run the tests](README.md#install-optional)