### PR TITLE
Export include directory when using Easylogging++ as a static library (Fix for #621)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 2.8.11)
 
 project(Easyloggingpp CXX)
 
@@ -33,8 +33,6 @@ set(ELPP_VERSION_STRING "${ELPP_MAJOR_VERSION}.${ELPP_MINOR_VERSION}.${ELPP_PATC
 set(ELPP_INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "The directory the headers are installed in")
 set(ELPP_PKGCONFIG_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/share/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
-
 install(FILES
     src/easylogging++.h
     src/easylogging++.cc
@@ -53,6 +51,8 @@ if (build_static_lib)
 
         require_cpp11()
         add_library(easyloggingpp STATIC src/easylogging++.cc)
+
+        target_include_directories(easyloggingpp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
         install(TARGETS
             easyloggingpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,12 @@ if (build_static_lib)
 
         require_cpp11()
         add_library(easyloggingpp STATIC src/easylogging++.cc)
-
-        target_include_directories(easyloggingpp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
+        
+        target_include_directories(easyloggingpp 
+            PUBLIC 
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+                $<INSTALL_INTERFACE:src>
+        )
 
         install(TARGETS
             easyloggingpp


### PR DESCRIPTION
This makes the Easylogging++ more usable as a static library: now, the user can just add it as a sub-directory to his CMakeLists.txt and then user target_link_libraries( target_name easyloggingpp ) to both link the library to his project and add an include directory.

Also, I removed useless include_directories command which used a directory which (no longer?) exists.

The change only affects build system, and only for the case where build_static_lib flag is ON. It, however, requires a newer version of CMake (at least 2.8.11). I tested it with CMake 3.11, and it worked.