### PR TITLE
Fixed unused variable warning while build without performance logging feature

### DIFF
--- a/src/easylogging++.cc
+++ b/src/easylogging++.cc
@@ -2078,10 +2078,12 @@ Storage::Storage(const LogBuilderPtr& defaultLogBuilder) :
   // We register default logger anyway (worse case it's not going to register) just in case
   m_registeredLoggers->get("default");
   // Register performance logger and reconfigure format
+#if defined(ELPP_FEATURE_ALL) || defined(ELPP_FEATURE_PERFORMANCE_TRACKING)
   Logger* performanceLogger = m_registeredLoggers->get(std::string(base::consts::kPerformanceLoggerId));
   m_registeredLoggers->get("performance");
   performanceLogger->configurations()->setGlobally(ConfigurationType::Format, std::string("%datetime %level %msg"));
   performanceLogger->reconfigure();
+#endif
 #if defined(ELPP_SYSLOG)
   // Register syslog logger and reconfigure format
   Logger* sysLogLogger = m_registeredLoggers->get(std::string(base::consts::kSysLogLoggerId));

--- a/src/easylogging++.h
+++ b/src/easylogging++.h
@@ -734,10 +734,12 @@ static const char* kDefaultLoggerId                        =      ELPP_DEFAULT_L
 static const char* kDefaultLoggerId                        =      "default";
 #endif
 
+#if defined(ELPP_FEATURE_ALL) || defined(ELPP_FEATURE_PERFORMANCE_TRACKING)
 #ifdef ELPP_DEFAULT_PERFORMANCE_LOGGER
 static const char* kPerformanceLoggerId                    =      ELPP_DEFAULT_PERFORMANCE_LOGGER;
 #else
 static const char* kPerformanceLoggerId                    =      "performance";
+#endif
 #endif
 
 #if defined(ELPP_SYSLOG)


### PR DESCRIPTION
Fixed a unused variable warning from g++ 6.3.0 while building as a static library.
If neither `ELPP_FEATURE_ALL` nor `ELPP_FEATURE_PERFORMANCE_TRACKING` is defined, variable `static const char* kPerformanceLoggerId` is not used. When `-Werror` flag is used while building, this causes compilation error.

This is a small fix for building.
